### PR TITLE
fix: Skip permission change notifications for bot itself

### DIFF
--- a/src/main/kotlin/top/tbpdt/vanilla/AutoGroup.kt
+++ b/src/main/kotlin/top/tbpdt/vanilla/AutoGroup.kt
@@ -120,6 +120,7 @@ object AutoGroup : SimpleListenerHost() {
         val msg = when {
             origin.isOwner() || new.isOwner() -> PlainText("群主变了？？？")
             origin.isAdministrator() && !new.isOperator() -> At(member).plus(PlainText(" 的管理没了，好可惜"))
+            member.id == bot.id -> return
             else -> At(member).plus(PlainText(" 升职啦！"))
         }
         group.sendMessage(msg)


### PR DESCRIPTION
To avoid message like this:

![image](https://github.com/user-attachments/assets/73c1bcba-e3da-414e-9c35-ed4076fa052e)
